### PR TITLE
8.8" screen support

### DIFF
--- a/TuringSmartScreenLib.Helpers.GDI/Extensions.cs
+++ b/TuringSmartScreenLib.Helpers.GDI/Extensions.cs
@@ -1,0 +1,36 @@
+namespace TuringSmartScreenLib.Helpers.GDI;
+
+using System.Drawing;
+
+public static class Extensions
+{
+    public static IScreenBuffer CreateBufferFrom(this IScreen screen, Bitmap bitmap)
+    {
+        var buffer = screen.CreateBuffer(bitmap.Width, bitmap.Height);
+        buffer.ReadFrom(bitmap);
+        return buffer;
+    }
+
+    public static IScreenBuffer CreateBufferFrom(this IScreen screen, Bitmap bitmap, int sx, int sy, int sw, int sh)
+    {
+        var buffer = screen.CreateBuffer(sw, sh);
+        buffer.ReadFrom(bitmap, sx, sy, sw, sh);
+        return buffer;
+    }
+
+    public static void ReadFrom(this IScreenBuffer buffer, Bitmap bitmap) =>
+       buffer.ReadFrom(bitmap, 0, 0, bitmap.Width, bitmap.Height);
+
+    public static void ReadFrom(this IScreenBuffer buffer, Bitmap bitmap, int sx, int sy, int sw, int sh)
+    {
+        for (var y = 0; y < sh; y++)
+        {
+            for (var x = 0; x < sw; x++)
+            {
+                var color = bitmap.GetPixel(x + sx, y + sy);
+
+                buffer.SetPixel(x, y, color.R, color.G, color.B);
+            }
+        }
+    }
+}

--- a/TuringSmartScreenLib.Helpers.GDI/TuringSmartScreenLib.Helpers.GDI.csproj
+++ b/TuringSmartScreenLib.Helpers.GDI/TuringSmartScreenLib.Helpers.GDI.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TuringSmartScreenLib\TuringSmartScreenLib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TuringSmartScreenLib.sln
+++ b/TuringSmartScreenLib.sln
@@ -26,6 +26,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Example2", "Example2\Exampl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TuringSmartScreenTool", "TuringSmartScreenTool\TuringSmartScreenTool.csproj", "{7DED3D32-4071-41BC-913E-A6BE94B4F6A9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TuringSmartScreenLib.Helpers.GDI", "TuringSmartScreenLib.Helpers.GDI\TuringSmartScreenLib.Helpers.GDI.csproj", "{6E826D66-B8A4-4B69-A1BF-D92FA8A27B01}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -52,6 +54,10 @@ Global
 		{7DED3D32-4071-41BC-913E-A6BE94B4F6A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7DED3D32-4071-41BC-913E-A6BE94B4F6A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7DED3D32-4071-41BC-913E-A6BE94B4F6A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E826D66-B8A4-4B69-A1BF-D92FA8A27B01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E826D66-B8A4-4B69-A1BF-D92FA8A27B01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E826D66-B8A4-4B69-A1BF-D92FA8A27B01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E826D66-B8A4-4B69-A1BF-D92FA8A27B01}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TuringSmartScreenLib/RevisionE.Abstractions.cs
+++ b/TuringSmartScreenLib/RevisionE.Abstractions.cs
@@ -1,0 +1,45 @@
+namespace TuringSmartScreenLib;
+
+internal sealed class ScreenWrapperRevisionE : ScreenBase
+{
+    private readonly TuringSmartScreenRevisionE screen;
+
+    public ScreenWrapperRevisionE(TuringSmartScreenRevisionE screen)
+        : base(screen.Width, screen.Height)
+    {
+        this.screen = screen;
+    }
+
+    public override void Dispose() => screen.Dispose();
+
+    public override void Reset()
+    {
+        // Do Nothing
+    }
+
+    public override void Clear() => screen.Clear();
+
+    public override void ScreenOff()
+    {
+        // Emulation
+        SetBrightness(0);
+    }
+
+    public override void ScreenOn()
+    {
+        // Emulation
+        SetBrightness(100);
+    }
+
+    public override void SetBrightness(byte level) => screen.SetBrightness(level);
+
+    protected override bool SetOrientation(ScreenOrientation orientation)
+    {
+        // TODO Emulation ?
+        return false;
+    }
+
+    public override IScreenBuffer CreateBuffer(int width, int height) => new TuringSmartScreenBufferE(width, height);
+
+    public override void DisplayBuffer(int x, int y, IScreenBuffer buffer) => screen.DisplayBitmap(x, y, ((TuringSmartScreenBufferE)buffer).Buffer, buffer.Width, buffer.Height);
+}

--- a/TuringSmartScreenLib/RevisionE.ScreenBuffer.cs
+++ b/TuringSmartScreenLib/RevisionE.ScreenBuffer.cs
@@ -1,0 +1,66 @@
+namespace TuringSmartScreenLib;
+
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+#pragma warning disable IDE0032
+// ReSharper disable ConvertToAutoProperty
+public sealed class TuringSmartScreenBufferE : IScreenBuffer
+{
+    private readonly int width;
+
+    private readonly int height;
+
+    private byte[] buffer;
+
+    public int Width => width;
+
+    public int Height => height;
+
+    internal byte[] Buffer => buffer;
+
+    public TuringSmartScreenBufferE(int width, int height)
+    {
+        this.width = width;
+        this.height = height;
+        buffer = ArrayPool<byte>.Shared.Rent(width * height * 3);
+        buffer.AsSpan().Clear();
+    }
+
+    public void Dispose()
+    {
+        if (buffer.Length > 0)
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+            buffer = [];
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetPixel(int x, int y, byte r, byte g, byte b)
+    {
+        var offset = ((y * width) + x) * 3;
+        buffer[offset] = b;
+        buffer[offset + 1] = g;
+        buffer[offset + 2] = r;
+    }
+
+    public void Clear(byte r = 0, byte g = 0, byte b = 0)
+    {
+        if ((r == g) && (r == b))
+        {
+            buffer.AsSpan(0, width * height * 2).Fill(r);
+        }
+        else
+        {
+            for (var offset = 0; offset < width * height * 3; offset += 3)
+            {
+                buffer[offset] = b;
+                buffer[offset + 1] = g;
+                buffer[offset + 2] = r;
+            }
+        }
+    }
+}
+// ReSharper restore ConvertToAutoProperty
+#pragma warning restore IDE0032

--- a/TuringSmartScreenLib/RevisionE.cs
+++ b/TuringSmartScreenLib/RevisionE.cs
@@ -1,0 +1,309 @@
+namespace TuringSmartScreenLib;
+
+using System;
+using System.Buffers;
+using System.IO.Ports;
+using System.Reflection;
+
+public sealed unsafe class TuringSmartScreenRevisionE : IDisposable
+{
+    private const int WriteSize = 250;
+    private const int ReadSize = 1024;
+    private const int ReadHelloSize = 23;
+
+    private static readonly byte[] CommandHello = [0x01, 0xef, 0x69, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0xc5, 0xd3];
+    private static readonly byte[] CommandSetBrightness = [0x7b, 0xef, 0x69, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00];
+    private static readonly byte[] CommandDisplayBitmap = [0xc8, 0xef, 0x69, 0x00, 0x38, 0x40, 0x00];
+    private static readonly byte[] CommandPreUpdateBitmap = [0x86, 0xef, 0x69, 0x00, 0x00, 0x00, 0x01];
+    private static readonly byte[] CommandUpdateBitmap = [0xcc, 0xef, 0x69, 0x00, 0x00];
+    private static readonly byte[] CommandQueryStatus = [0xcf, 0xef, 0x69, 0x00, 0x00, 0x00, 0x01];
+
+    private static readonly byte[] CommandUpdateBitmapTerminate = [0xef, 0x69];
+
+    private readonly SerialPort port;
+
+    private byte[] writeBuffer;
+
+    private byte[] readBuffer;
+
+    private int writeOffset;
+
+#pragma warning disable CA1822
+    public int Width => 480;
+
+    public int Height => 1920;
+#pragma warning restore CA1822
+
+    public TuringSmartScreenRevisionE(string name)
+    {
+        port = new SerialPort(name)
+        {
+            DtrEnable = true,
+            RtsEnable = true,
+            ReadTimeout = 1000,
+            WriteTimeout = 1000,
+            BaudRate = 115200,
+            StopBits = StopBits.One,
+            Parity = Parity.None
+        };
+        writeBuffer = ArrayPool<byte>.Shared.Rent(WriteSize);
+        readBuffer = ArrayPool<byte>.Shared.Rent(ReadSize);
+    }
+
+    public void Dispose()
+    {
+        Close();
+
+        if (writeBuffer.Length > 0)
+        {
+            ArrayPool<byte>.Shared.Return(writeBuffer);
+            writeBuffer = [];
+        }
+        if (readBuffer.Length > 0)
+        {
+            ArrayPool<byte>.Shared.Return(readBuffer);
+            readBuffer = [];
+        }
+    }
+
+    public void Close()
+    {
+        if (port.IsOpen)
+        {
+            try
+            {
+                port.Close();
+            }
+            catch (IOException)
+            {
+                // Ignore
+            }
+            catch (TargetInvocationException)
+            {
+                // Ignore
+            }
+        }
+    }
+
+    public void Open()
+    {
+        port.Open();
+        port.DiscardInBuffer();
+        port.DiscardOutBuffer();
+
+        Write(CommandHello);
+        Flush();
+
+        var response = ReadResponse(ReadHelloSize);
+        var expectedResponseData = "chs_88inch"u8;
+        if ((response.Length != ReadHelloSize) || !response[..10].SequenceEqual(expectedResponseData))
+        {
+            throw new IOException($"Unknown response. result={(response.Length != ReadHelloSize)},{!response[..10].SequenceEqual(expectedResponseData)} length={response.Length} expected={ReadHelloSize} response=[{Convert.ToHexString(response[..10])}] expected=[{Convert.ToHexString(expectedResponseData)}]");
+        }
+    }
+
+    private ReadOnlySpan<byte> ReadResponse(int length = ReadSize)
+    {
+        var offset = 0;
+        try
+        {
+            while (offset < length)
+            {
+                var read = port.Read(readBuffer, offset, length - offset);
+                if (read <= 0)
+                {
+                    break;
+                }
+
+                offset += read;
+            }
+        }
+        catch (IOException)
+        {
+            // Ignore
+        }
+
+        return readBuffer.AsSpan(0, offset);
+    }
+
+    private void Write(ReadOnlySpan<byte> values, byte pad = 0x00)
+    {
+        while (writeOffset + values.Length > WriteSize - 1)
+        {
+            var block = values[..(WriteSize - 1 - writeOffset)];
+            block.CopyTo(writeBuffer.AsSpan(writeOffset, block.Length));
+            writeOffset += block.Length;
+
+            FlushInternal(pad);
+
+            values = values[block.Length..];
+        }
+
+        if (values.Length > 0)
+        {
+            values.CopyTo(writeBuffer.AsSpan(writeOffset));
+            writeOffset += values.Length;
+        }
+    }
+
+    private void Write(byte value, byte pad = 0x00)
+    {
+        if (writeOffset + 1 > WriteSize - 1)
+        {
+            FlushInternal(pad);
+        }
+
+        writeBuffer[writeOffset] = value;
+        writeOffset++;
+    }
+
+    private void Flush(byte pad = 0x00)
+    {
+        if (writeOffset > 0)
+        {
+            FlushInternal(pad);
+        }
+    }
+
+    private void FlushInternal(byte pad)
+    {
+        writeBuffer.AsSpan(writeOffset, WriteSize - writeOffset).Fill(pad);
+        port.Write(writeBuffer, 0, WriteSize);
+        writeOffset = 0;
+    }
+
+    public void Clear(byte r = 0, byte g = 0, byte b = 0)
+    {
+        // Start
+        Write(0x2c);
+        Flush(0x2c);
+
+        // DisplayBitmap
+        Write(CommandDisplayBitmap);
+        Flush();
+
+        // Payload
+        var pattern = (Span<byte>)stackalloc byte[4];
+        pattern[0] = b;
+        pattern[1] = g;
+        pattern[2] = r;
+        pattern[3] = 0xff;
+        for (var y = 0; y < Height; y++)
+        {
+            for (var x = 0; x < Width; x++)
+            {
+                Write(pattern);
+            }
+        }
+        Flush();
+
+        // PreUpdateBitmap
+        Write(CommandPreUpdateBitmap);
+        Flush();
+        ReadResponse();
+
+        // QueryStatus
+        Write(CommandQueryStatus);
+        Flush();
+        ReadResponse();
+    }
+
+    public void SetBrightness(int level)
+    {
+        Write(CommandSetBrightness);
+        Write((byte)level);
+        Flush();
+    }
+
+    public void DisplayBitmap(int x, int y, byte[] bitmap, int width, int height)
+    {
+        if ((x == 0) && (y == 0) && (width == Width) && (height == Height))
+        {
+            DisplayFullBitmap(bitmap);
+        }
+        else
+        {
+            DisplayPartialBitmap(x, y, bitmap, width, height);
+        }
+    }
+
+    private void DisplayFullBitmap(byte[] bitmap)
+    {
+        // Start
+        Write(0x2c);
+        Flush(0x2c);
+
+        // DisplayBitmap
+        Write(CommandDisplayBitmap);
+        Flush();
+
+        // Payload
+        for (var y = 0; y < Height; y++)
+        {
+            for (var x = 0; x < Width; x++)
+            {
+                var offset = ((y * Width) + x) * 3;
+                Write(bitmap.AsSpan(offset, 3));
+                Write(0xff);
+            }
+        }
+        Flush();
+
+        // PreUpdateBitmap
+        Write(CommandPreUpdateBitmap);
+        Flush();
+        ReadResponse();
+
+        // QueryStatus
+        Write(CommandQueryStatus);
+        Flush();
+        ReadResponse();
+    }
+
+    private void DisplayPartialBitmap(int x, int y, byte[] bitmap, int width, int height)
+    {
+        var header = (Span<byte>)stackalloc byte[5];
+        header[3] = (byte)((width >> 8) & 0xff);
+        header[4] = (byte)(width & 0xff);
+
+        var bitmapSize = (((width * 3) + header.Length) * height) + CommandUpdateBitmapTerminate.Length;
+        var size = (Span<byte>)stackalloc byte[2];
+        size[0] = (byte)((bitmapSize >> 8) & 0xff);
+        size[1] = (byte)(bitmapSize & 0xff);
+
+        for (var i = 0; i < 2; i++)
+        {
+            // UpdateBitmap
+            Write(CommandUpdateBitmap);
+            Write(size);
+            Flush();
+
+            // Payload
+            for (var h = 0; h < height; h++)
+            {
+                var position = ((x + h) * Width) + y;
+                header[0] = (byte)((position >> 16) & 0xff);
+                header[1] = (byte)((position >> 8) & 0xff);
+                header[2] = (byte)(position & 0xff);
+                Write(header);
+                for (var w = 0; w < width; w++)
+                {
+                    var offset = ((h * width) + w) * 3;
+                    Write(bitmap.AsSpan(offset, 3));
+                }
+            }
+            Write(CommandUpdateBitmapTerminate);
+            Flush();
+
+            // UpdateBitmap
+            Write(CommandQueryStatus);
+            Flush();
+
+            var response = ReadResponse();
+            if ((response.Length != ReadSize) || (response.IndexOf("needReSend:0"u8) >= 0))
+            {
+                break;
+            }
+        }
+    }
+}

--- a/TuringSmartScreenLib/ScreenFactory.cs
+++ b/TuringSmartScreenLib/ScreenFactory.cs
@@ -27,6 +27,13 @@ public static class ScreenFactory
             return new ScreenWrapperRevisionC(screen);
         }
 
+        if (type == ScreenType.RevisionE)
+        {
+            var screen = new TuringSmartScreenRevisionE(name);
+            screen.Open();
+            return new ScreenWrapperRevisionE(screen);
+        }
+
         throw new NotSupportedException("Unsupported type.");
     }
 }

--- a/TuringSmartScreenLib/ScreenType.cs
+++ b/TuringSmartScreenLib/ScreenType.cs
@@ -4,5 +4,6 @@ public enum ScreenType
 {
     RevisionA,
     RevisionB,
-    RevisionC
+    RevisionC,
+    RevisionE
 }


### PR DESCRIPTION
This pull request introduces several significant changes and additions to the `TuringSmartScreenLib` project, primarily focusing on adding support for a new screen type, Revision E. The changes include new classes, methods, and project configurations to handle the new screen type and its buffer operations.

### New Screen Type Support:

* [`TuringSmartScreenLib/ScreenType.cs`](diffhunk://#diff-e3952936282c570356bc54109f38eeaab032721b898dd96c039a8f89dcdade5fL7-R8): Added a new enum value `RevisionE` to the `ScreenType` enumeration.
* [`TuringSmartScreenLib/ScreenFactory.cs`](diffhunk://#diff-a5ee60d5665f4822efd4d7a05dbe130f19b2dd02e3f5d3088da0bcf1572c8d4aR30-R36): Updated the `Create` method to handle `ScreenType.RevisionE` by initializing and returning a new `ScreenWrapperRevisionE` instance.

### New Classes and Methods:

* [`TuringSmartScreenLib/RevisionE.Abstractions.cs`](diffhunk://#diff-ae65a74e449963d1ee1bf2fb8642a6582943c19856dd47793720dbc631e07df9R1-R45): Introduced the `ScreenWrapperRevisionE` class, which extends `ScreenBase` and provides methods to interact with the new screen type.
* [`TuringSmartScreenLib/RevisionE.ScreenBuffer.cs`](diffhunk://#diff-5258e7cadeb8e3cde477ed2fdd0c97b20f1fc11f814851074b40b9c9ff8769efR1-R66): Added the `TuringSmartScreenBufferE` class implementing `IScreenBuffer`, which manages the pixel buffer for the new screen type.
* [`TuringSmartScreenLib/RevisionE.cs`](diffhunk://#diff-0eca1f991f96071a065af188f5a594b2150bf6fedb753f48553c2ca3558da589R1-R309): Created the `TuringSmartScreenRevisionE` class, which includes methods for screen operations such as opening, closing, setting brightness, and displaying bitmaps.

### Project Configuration:

* [`TuringSmartScreenLib.Helpers.GDI/TuringSmartScreenLib.Helpers.GDI.csproj`](diffhunk://#diff-9e114afc89dc0da6aa2bee8bf141c2bdd0f387c132a41acf6b118825cc9c245bR1-R17): Added a new project file to include dependencies and references necessary for the new screen type.
* [`TuringSmartScreenLib.sln`](diffhunk://#diff-ebff4f85abeccdb92f96736cf1b421459a82b843a091bd41ef8e0dce7cebe098R29-R30): Updated the solution file to include the new `TuringSmartScreenLib.Helpers.GDI` project. [[1]](diffhunk://#diff-ebff4f85abeccdb92f96736cf1b421459a82b843a091bd41ef8e0dce7cebe098R29-R30) [[2]](diffhunk://#diff-ebff4f85abeccdb92f96736cf1b421459a82b843a091bd41ef8e0dce7cebe098R57-R60)

### Extensions and Utilities:

* [`TuringSmartScreenLib.Helpers.GDI/Extensions.cs`](diffhunk://#diff-b7f4901499b0b46f12e06b7ecb3e0020870b47ee1c288b2ff07d19caeee0c7a7R1-R36): Added extension methods for creating and reading from screen buffers using `Bitmap` objects.