### PR TITLE
Fix partial update for Revision C & E

### DIFF
--- a/Example2/Program.cs
+++ b/Example2/Program.cs
@@ -23,7 +23,14 @@ screen.DisplayBuffer(0, 0, buffer1);
 using var bitmap2 = SKBitmap.Decode("test2-crop.png");
 using var buffer2 = screen.CreateBufferFrom(bitmap2);
 
-for (var i = 0; i < screen.Height - buffer2.Height; i++)
-{
-    screen.DisplayBuffer(i, i, buffer2);
-}
+//display at top left corner
+screen.DisplayBuffer(0, 0, buffer2);
+
+//display at bottom left corner
+screen.DisplayBuffer(0, screen.Height - bitmap2.Height, buffer2);
+
+//display at top right corner
+screen.DisplayBuffer(screen.Width - bitmap2.Width, 0, buffer2);
+
+//display at bottom right corner
+screen.DisplayBuffer(screen.Width - bitmap2.Width, screen.Height - bitmap2.Height, buffer2);

--- a/TuringSmartScreenLib/RevisionC.cs
+++ b/TuringSmartScreenLib/RevisionC.cs
@@ -106,8 +106,6 @@ public sealed unsafe class TuringSmartScreenRevisionC : IDisposable
 
     private ReadOnlySpan<byte> ReadResponse(int length = ReadSize)
     {
-        port.DiscardInBuffer();
-
         var offset = 0;
         try
         {

--- a/TuringSmartScreenLib/RevisionC.cs
+++ b/TuringSmartScreenLib/RevisionC.cs
@@ -290,7 +290,7 @@ public sealed unsafe class TuringSmartScreenRevisionC : IDisposable
         // Payload
         for (var h = 0; h < height; h++)
         {
-            var position = ((x + h) * Width) + y;
+            var position = ((y + h) * Width) + x;
             header[0] = (byte)((position >> 16) & 0xff);
             header[1] = (byte)((position >> 8) & 0xff);
             header[2] = (byte)(position & 0xff);


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and performance of the `TuringSmartScreenLib` library and modify the display logic in `Example2/Program.cs`. The most important changes include fixing a coordinate calculation bug, adding a render count for tracking, and modifying the display logic to handle different screen positions.

### Improvements to `TuringSmartScreenLib`:

* Fixed the coordinate calculation in `DisplayPartialBitmap` to correctly compute the position based on `(y + h) * Width + x` instead of `(x + h) * Width + y` (`TuringSmartScreenLib/RevisionC.cs`).
* Added a `renderCount` variable to track the number of times a bitmap is rendered and included this count in the header of the bitmap update command (`TuringSmartScreenLib/RevisionE.cs`). [[1]](diffhunk://#diff-0eca1f991f96071a065af188f5a594b2150bf6fedb753f48553c2ca3558da589R32-R33) [[2]](diffhunk://#diff-0eca1f991f96071a065af188f5a594b2150bf6fedb753f48553c2ca3558da589L265-R293)
* Changed the `DisplayPartialBitmap` method to return a boolean indicating whether the response requires a resend and updated the `DisplayBitmap` method to handle this correctly (`TuringSmartScreenLib/RevisionE.cs`). [[1]](diffhunk://#diff-0eca1f991f96071a065af188f5a594b2150bf6fedb753f48553c2ca3558da589L223-R233) [[2]](diffhunk://#diff-0eca1f991f96071a065af188f5a594b2150bf6fedb753f48553c2ca3558da589L305-R313)

### Modifications to display logic in `Example2/Program.cs`:

* Updated the display logic to show the buffer in all four corners of the screen instead of iterating through the screen height (`Example2/Program.cs`).