### PR TITLE
Add StopMedia method to ScreenDevice

### DIFF
--- a/LcdDriver.TuringSmartScreen/ScreenDevice.cs
+++ b/LcdDriver.TuringSmartScreen/ScreenDevice.cs
@@ -186,4 +186,10 @@ public sealed class ScreenDevice : IDisposable
         BinaryPrimitives.WriteInt32BigEndian(commandBuffer.AsSpan(8, 4), imageBytes.Length);
         return RequestResponse(imageBytes);
     }
+
+    public bool StopMedia()
+    {
+        PrepareCommandHeader(111);
+        return RequestResponse();
+    }
 }


### PR DESCRIPTION
Introduce StopMedia() to ScreenDevice to send command 111 and invoke RequestResponse(), returning a boolean success indicator. This adds a simple API to stop media playback from the device by preparing the command header and issuing the request.

Sending JPEG to a device that may be having a media playback will result in flickering. PNG overlays transparency properly do it does not have this issue, but JPEG is superior in term of frame rate (~3x).